### PR TITLE
Bumping goodle_drive_oauth version & major version number for gem

### DIFF
--- a/google_drive_oauth.gemspec
+++ b/google_drive_oauth.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "google_drive", "~> 1.0.0"
+  spec.add_dependency "google_drive", "~> 2.1"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/google_drive/oauth/version.rb
+++ b/lib/google_drive/oauth/version.rb
@@ -1,5 +1,5 @@
 module GoogleDrive
   module Oauth
-    VERSION = "0.0.2"
+    VERSION = "1.0.0"
   end
 end


### PR DESCRIPTION
- bumping the major version is necessary because google_drive_oauth
2.x.x [breaks](https://github.com/gimite/google-drive-ruby/blob/master/MIGRATING.md) 1.x.x